### PR TITLE
enable multithreading for point upload

### DIFF
--- a/Python/script/send-coordinates-to-backend/send_points.py
+++ b/Python/script/send-coordinates-to-backend/send_points.py
@@ -1,43 +1,57 @@
 import pandas as pd
 import requests
+from tqdm import tqdm
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+def send_parking_spot(session, url, row):
+    point_data = {
+        "longlat": {
+            "type": "Point",
+            "coordinates": [row['longitude'], row['latitude']]
+        },
+        "type": "parking",
+        "details": {}
+    }
+    try:
+        response = session.post(url, json=point_data)
+        if response.status_code in (200, 201):
+            return True
+        else:
+            print(f"Failed to add point: {response.status_code}, {response.text}")
+            return False
+    except Exception as e:
+        print(f"Error sending data to API: {e}")
+        return False
 
 def send_parking_spots_to_api(data):
     """
-    Function to send the data as post requests to the backend
+    Function to send the data as POST requests to the backend using multithreading.
     """
     url = "http://localhost:8080/v1/private/points/"
-
     successful_posts = 0
+    total = len(data)
 
-    for index, row in data.iterrows():
-        point_data = {
-            "longlat": {
-                "type": "Point",
-                "coordinates": [row['longitude'], row['latitude']]
-            },
-            "type": "parking",
-            "details": {
-            }
-        }
-        
-        try:
-            response = requests.post(url, json=point_data)
-            
-            if response.status_code == 200 or response.status_code == 201:
-                print(f"Successfully added point with longitude {row['longitude']} and latitude {row['latitude']}")
-                successful_posts += 1
-            else:
-                print(f"Failed to add point: {response.status_code}, {response.text}")
-        
-        except Exception as e:
-            print(f"Error sending data to API: {e}")
-    
-    print(f"Total successful posts: {successful_posts}/{len(data)}")
+    # Create a shared session
+    session = requests.Session()
 
+    with ThreadPoolExecutor() as executor:
+        futures = []
+        for index, row in data.iterrows():
+            futures.append(executor.submit(send_parking_spot, session, url, row))
+
+        with tqdm(total=total, desc="Uploading parking spots", unit="spot") as pbar:
+            for future in as_completed(futures):
+                result = future.result()
+                if result:
+                    successful_posts += 1
+                pbar.update(1)
+                pbar.set_postfix(successful=successful_posts, failed=(pbar.n - successful_posts))
+
+    session.close()
 
 def read_csv_file(csv_file_path):
     """
-    Functiion to read the csv file in a pandas dataframe
+    Function to read the CSV file into a pandas DataFrame.
     """
     try:
         data = pd.read_csv(csv_file_path)
@@ -48,13 +62,11 @@ def read_csv_file(csv_file_path):
 
 def main(csv_file_path):
     """
-    Main function to send all the coordiantes in a csv file to the backend
+    Main function to send all the coordinates in a CSV file to the backend.
     """
     data = read_csv_file(csv_file_path)
-
     if data is not None:
         send_parking_spots_to_api(data)
 
-
 if __name__ == "__main__":
-    main('coordinates_in_-6.3072_53.4044--6.3031_53.4068.csv')
+    main('./output.csv')

--- a/Python/script/send-coordinates-to-backend/send_points.py
+++ b/Python/script/send-coordinates-to-backend/send_points.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import requests
+import sys
 from tqdm import tqdm
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -27,7 +28,7 @@ def send_parking_spots_to_api(data):
     """
     Function to send the data as POST requests to the backend using multithreading.
     """
-    url = "http://localhost:8080/v1/private/points/"
+    url = "http://localhost:8080/v1/private/points/" # This is intentionally hardcoded, this will never change in prod
     successful_posts = 0
     total = len(data)
 
@@ -69,4 +70,4 @@ def main(csv_file_path):
         send_parking_spots_to_api(data)
 
 if __name__ == "__main__":
-    main('./output.csv')
+    main(sys.argv[1])


### PR DESCRIPTION
### Description

This PR refactors our `send_points` script to enable multithreading, increasing our point upload from `10.1125` to `809.75` points per second. This improved our database upload time from `3.17` hours to approximately ``2.3`` minutes.

For context, this is an `8,000%` increase in performance. 

### Type of change

Please select the option that best describes the changes made:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Changes

- **Refactors `send_points` to enable multithreading**
- **Refactors `send_points` to take input csv as an argument**