### PR TITLE
fix bug/remove signup protected path

### DIFF
--- a/Frontend/src/app/components/ProtectedRoute.tsx
+++ b/Frontend/src/app/components/ProtectedRoute.tsx
@@ -1,19 +1,20 @@
-"use client"; 
+"use client";
 
 import { useEffect } from "react";
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 
 const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     const router = useRouter();
+    const pathname = usePathname();
 
     useEffect(() => {
         const userId = localStorage.getItem('userId');
-        if (!userId) {
-            if (router) {
-                router.push('/login'); // if no token, redirect to login page
-            }
+        const unprotectedPaths = ['/signup', '/forgot-password']; // add unprotected paths
+
+        if (!userId && !unprotectedPaths.includes(pathname)) {
+            router.push('/login'); // if no token, and not in unprotected paths, redirect to login page
         }
-    }, [router]);
+    }, [router, pathname]);
 
     return <>{children}</>;
 };


### PR DESCRIPTION
### Description

Rapid fix the keeping redirecting to login page from sign up page

Fixes # (issue)

### Type of change

Please select the option that best describes the changes made:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Changes

Add unprotected path to signup and forget password. If no token, these page will not redict to login page.