### PR TITLE
backend/login use session

### DIFF
--- a/Backend/internal/dtos/login_user_dto.go
+++ b/Backend/internal/dtos/login_user_dto.go
@@ -11,8 +11,7 @@ import (
 )
 
 type UserLoginDto struct {
-	Username string `json:"username"`
-	Email    string `json:"email"`
+	UsernameOrEmail string `json:"usernameOrEmail"`
 	Password string `json:"password"`
 }
 
@@ -31,7 +30,7 @@ func (self *UserLoginDto) Validate() error {
 		return err
 	}
 
-	if len(self.Username) == 0 && len(self.Email) == 0 {
+	if len(self.UsernameOrEmail) == 0 {
 		err := customErrors.Parameter.RequiredParameterMissingError.WithCause(fmt.Errorf("Username or Email is required"))
 		return err
 	}

--- a/Backend/internal/dtos/login_user_response_dto.go
+++ b/Backend/internal/dtos/login_user_response_dto.go
@@ -1,0 +1,8 @@
+package dtos
+
+import "github.com/jackc/pgx/v5/pgtype"
+
+type UserLoginResponseDto struct {
+	UserId pgtype.UUID `json:"userid"`
+	Token  string      `json:"token"`
+}

--- a/Backend/internal/handlers/auth_public.go
+++ b/Backend/internal/handlers/auth_public.go
@@ -286,10 +286,10 @@ func (p *AuthHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	var userLogin db.Login
 	var err error
 
-	if len(loginDto.Username) != 0 {
-		userLogin, err = db.New(dbConn).GetLoginByUsername(*dbCtx, loginDto.Username)
-	} else {
-		userLogin, err = db.New(dbConn).GetLoginByEmail(*dbCtx, loginDto.Email)
+	userLogin, err = db.New(dbConn).GetLoginByEmail(*dbCtx, loginDto.UsernameOrEmail)
+	if err != nil {
+		// try again with username
+		userLogin, err = db.New(dbConn).GetLoginByUsername(*dbCtx, loginDto.UsernameOrEmail)
 	}
 
 	if err != nil {

--- a/Backend/internal/handlers/auth_public.go
+++ b/Backend/internal/handlers/auth_public.go
@@ -318,7 +318,7 @@ func (p *AuthHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	expiry := os.Getenv(expiryEnv)
 	if len(expiry) == 0 {
 		log.Printf("Warning: MAGPIE_JWT_EXPIRY not set, defaulting to 7d expiry")
-		expiry = "24h"
+		expiry = "168h"
 	}
 
 	parsedExpiry, err := time.ParseDuration(expiry)

--- a/Backend/internal/handlers/auth_public.go
+++ b/Backend/internal/handlers/auth_public.go
@@ -291,7 +291,7 @@ func (p *AuthHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	} else {
 		userLogin, err = db.New(dbConn).GetLoginByEmail(*dbCtx, loginDto.Email)
 	}
-	
+
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			resp.SendError(customErrors.Auth.WrongCredentialsError, w)
@@ -347,19 +347,9 @@ func (p *AuthHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cookie := http.Cookie{
-		Name:     "magpie_auth",
-		Value:    tokenString,
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-		Expires:  time.Now().Add(parsedExpiry),
-		Path:     "/",
-	}
-
-	http.SetCookie(w, &cookie)
-
-	tokenDto := dtos.UserIdDto{
+	tokenDto := dtos.UserLoginResponseDto{
 		UserId: userLogin.ID,
+		Token:  tokenString,
 	}
 
 	resp.SendResponse(dtos.ResponseContentDto{Content: tokenDto, HttpStatus: http.StatusOK}, w)

--- a/Backend/internal/handlers/auth_public_test.go
+++ b/Backend/internal/handlers/auth_public_test.go
@@ -133,23 +133,18 @@ const (
 				"ProfilePicture": "%s"
 			`
 
-	jsonLoginUserWithEmail = `{
-				"Email": "%s",
-				"Password": "%s"
-			}`
-
-	jsonLoginUserWithUsername = `{
-				"Username": "%s",
+	jsonLoginValid = `{
+				"UsernameOrEmail": "%s",
 				"Password": "%s"
 			}`
 
 	jsonLoginUserWithUsernameInvalid = `{
-				"Username": "%s",
+				"UsernameOrEmail": "%s",
 				"Password": "%s"
 			`
 
 	jsonLoginUserWithUsernamePasswordMissing = `{
-				"Username": "%s"
+				"UsernameOrEmail": "%s"
 			}`
 
 	jsonLoginUserUsernameAndEmailMissing = `{
@@ -1274,7 +1269,7 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 			Method:    "POST",
 			Route:     loginRoute,
 			Env:       defaultEnv,
-			InputJSON: fmt.Sprintf(jsonLoginUserWithEmail, email, pw),
+			InputJSON: fmt.Sprintf(jsonLoginValid, email, pw),
 			MockSetup: func(mock pgxmock.PgxPoolIface) {
 				mock.ExpectQuery(queryGetLoginByEmail).
 					WithArgs(email).
@@ -1290,8 +1285,12 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 			Method:    "POST",
 			Route:     loginRoute,
 			Env:       defaultEnv,
-			InputJSON: fmt.Sprintf(jsonLoginUserWithUsername, username, pw),
+			InputJSON: fmt.Sprintf(jsonLoginValid, username, pw),
 			MockSetup: func(mock pgxmock.PgxPoolIface) {
+				mock.ExpectQuery(queryGetLoginByEmail).
+					WithArgs(username).
+					WillReturnRows(pgxmock.NewRows(rowsGetLogin))
+
 				mock.ExpectQuery(queryGetLoginByUsername).
 					WithArgs(username).
 					WillReturnRows(pgxmock.NewRows(rowsGetLogin).AddRow(userId, username, email, pwHash))
@@ -1306,8 +1305,12 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 			Method:    "POST",
 			Route:     loginRoute,
 			Env:       defaultEnv,
-			InputJSON: fmt.Sprintf(jsonLoginUserWithUsername, username, pw),
+			InputJSON: fmt.Sprintf(jsonLoginValid, username, pw),
 			MockSetup: func(mock pgxmock.PgxPoolIface) {
+				mock.ExpectQuery(queryGetLoginByEmail).
+					WithArgs(username).
+					WillReturnRows(pgxmock.NewRows(rowsGetLogin))
+
 				mock.ExpectQuery(queryGetLoginByUsername).
 					WithArgs(username).
 					WillReturnRows(pgxmock.NewRows(rowsGetLogin).AddRow(userId, username, email, pwHashAlt))
@@ -1360,8 +1363,12 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 			Method:    "POST",
 			Route:     loginRoute,
 			Env:       defaultEnv,
-			InputJSON: fmt.Sprintf(jsonLoginUserWithUsername, username, pw),
+			InputJSON: fmt.Sprintf(jsonLoginValid, username, pw),
 			MockSetup: func(mock pgxmock.PgxPoolIface) {
+				mock.ExpectQuery(queryGetLoginByEmail).
+					WithArgs(username).
+					WillReturnRows(pgxmock.NewRows(rowsGetLogin))
+
 				mock.ExpectQuery(queryGetLoginByUsername).
 					WithArgs(username).
 					WillReturnRows(pgxmock.NewRows(rowsGetLogin))
@@ -1375,9 +1382,13 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 			Method:    "POST",
 			Route:     loginRoute,
 			Env:       defaultEnv,
-			InputJSON: fmt.Sprintf(jsonLoginUserWithEmail, email, pw),
+			InputJSON: fmt.Sprintf(jsonLoginValid, email, pw),
 			MockSetup: func(mock pgxmock.PgxPoolIface) {
 				mock.ExpectQuery(queryGetLoginByEmail).
+					WithArgs(email).
+					WillReturnRows(pgxmock.NewRows(rowsGetLogin))
+
+				mock.ExpectQuery(queryGetLoginByUsername).
 					WithArgs(email).
 					WillReturnRows(pgxmock.NewRows(rowsGetLogin))
 			},
@@ -1390,7 +1401,7 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 			Method:    "POST",
 			Route:     loginRoute,
 			Env:       jwtSecretMissingEnv,
-			InputJSON: fmt.Sprintf(jsonLoginUserWithEmail, email, pw),
+			InputJSON: fmt.Sprintf(jsonLoginValid, email, pw),
 			MockSetup: func(mock pgxmock.PgxPoolIface) {
 				mock.ExpectQuery(queryGetLoginByEmail).
 					WithArgs(email).
@@ -1405,9 +1416,13 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 			Method:    "POST",
 			Route:     loginRoute,
 			Env:       defaultEnv,
-			InputJSON: fmt.Sprintf(jsonLoginUserWithEmail, email, pw),
+			InputJSON: fmt.Sprintf(jsonLoginValid, email, pw),
 			MockSetup: func(mock pgxmock.PgxPoolIface) {
 				mock.ExpectQuery(queryGetLoginByEmail).
+					WithArgs(email).
+					WillReturnError(simulatedDbError)
+
+				mock.ExpectQuery(queryGetLoginByUsername).
 					WithArgs(email).
 					WillReturnError(simulatedDbError)
 
@@ -1420,8 +1435,12 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 			Method:    "POST",
 			Route:     loginRoute,
 			Env:       defaultEnv,
-			InputJSON: fmt.Sprintf(jsonLoginUserWithUsername, username, pw),
+			InputJSON: fmt.Sprintf(jsonLoginValid, username, pw),
 			MockSetup: func(mock pgxmock.PgxPoolIface) {
+				mock.ExpectQuery(queryGetLoginByEmail).
+					WithArgs(username).
+					WillReturnRows(pgxmock.NewRows(rowsGetLogin))
+
 				mock.ExpectQuery(queryGetLoginByUsername).
 					WithArgs(username).
 					WillReturnError(simulatedDbError)
@@ -1434,7 +1453,7 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 			Method:    "POST",
 			Route:     loginRoute,
 			Env:       defaultEnv,
-			InputJSON: fmt.Sprintf(jsonLoginUserWithEmail, email, pw),
+			InputJSON: fmt.Sprintf(jsonLoginValid, email, pw),
 			MockSetup: func(mock pgxmock.PgxPoolIface) {
 				mock.ExpectQuery(queryGetLoginByEmail).
 					WithArgs(email).

--- a/Backend/internal/handlers/auth_public_test.go
+++ b/Backend/internal/handlers/auth_public_test.go
@@ -1260,7 +1260,6 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	duration, err := time.ParseDuration(`168h`)
 	if err != nil {
 		t.Errorf("Could not parse jwt duration: %v", err)
 	}
@@ -1279,15 +1278,6 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 
 				mock.ExpectExec(queryUpdateLastLogin).WithArgs(userId).WillReturnResult(resultUpdated)
 			},
-			ExpectedCookies: []*http.Cookie{
-				{
-					Name:     "magpie_auth",
-					HttpOnly: true,
-					SameSite: http.SameSiteLaxMode,
-					Expires:  time.Now().Add(duration),
-					Path:     "/",
-				},
-			},
 			ExpectedStatus: http.StatusOK,
 			ExpectedJSON:   fmt.Sprintf(jsonResponseUserId, userIdString),
 		},
@@ -1304,15 +1294,6 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 
 				mock.ExpectExec(queryUpdateLastLogin).WithArgs(userId).WillReturnResult(resultUpdated)
 			},
-			ExpectedCookies: []*http.Cookie{
-				{
-					Name:     "magpie_auth",
-					HttpOnly: true,
-					SameSite: http.SameSiteLaxMode,
-					Expires:  time.Now().Add(duration),
-					Path:     "/",
-				},
-			},
 			ExpectedStatus: http.StatusOK,
 			ExpectedJSON:   fmt.Sprintf(jsonResponseUserId, userIdString),
 		},
@@ -1327,7 +1308,6 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 					WithArgs(username).
 					WillReturnRows(pgxmock.NewRows(rowsGetLogin).AddRow(userId, username, email, pwHashAlt))
 			},
-			ExpectedCookies: []*http.Cookie{},
 			ExpectedStatus:  http.StatusUnauthorized,
 			ExpectedError:   errors.Auth.WrongCredentialsError.ErrorMsg,
 			ExpectedJSON:    jsonWrongCredentialsError,
@@ -1341,7 +1321,6 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 			MockSetup: func(mock pgxmock.PgxPoolIface) {
 				// should return before any database calls are made
 			},
-			ExpectedCookies: []*http.Cookie{},
 			ExpectedStatus:  http.StatusBadRequest,
 			ExpectedError:   errors.Parameter.RequiredParameterMissingError.ErrorMsg,
 			ExpectedJSON:    jsonPasswordRequiredError,
@@ -1355,7 +1334,6 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 			MockSetup: func(mock pgxmock.PgxPoolIface) {
 				// should return before any database calls are made
 			},
-			ExpectedCookies: []*http.Cookie{},
 			ExpectedStatus:  http.StatusBadRequest,
 			ExpectedError:   errors.Parameter.RequiredParameterMissingError.ErrorMsg,
 			ExpectedJSON:    jsonUsernameOrEmailRequiredError,
@@ -1369,7 +1347,6 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 			MockSetup: func(mock pgxmock.PgxPoolIface) {
 				// should return before any database calls are made
 			},
-			ExpectedCookies: []*http.Cookie{},
 			ExpectedStatus:  http.StatusBadRequest,
 			ExpectedError:   errors.Payload.InvalidPayloadUserError.ErrorMsg,
 			ExpectedJSON:    jsonInvalidUserPayloadError,
@@ -1385,7 +1362,6 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 					WithArgs(username).
 					WillReturnRows(pgxmock.NewRows(rowsGetLogin))
 			},
-			ExpectedCookies: []*http.Cookie{},
 			ExpectedStatus:  http.StatusUnauthorized,
 			ExpectedError:   errors.Auth.WrongCredentialsError.ErrorMsg,
 			ExpectedJSON:    jsonWrongCredentialsError,
@@ -1401,7 +1377,6 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 					WithArgs(email).
 					WillReturnRows(pgxmock.NewRows(rowsGetLogin))
 			},
-			ExpectedCookies: []*http.Cookie{},
 			ExpectedStatus:  http.StatusUnauthorized,
 			ExpectedError:   errors.Auth.WrongCredentialsError.ErrorMsg,
 			ExpectedJSON:    jsonWrongCredentialsError,
@@ -1418,7 +1393,6 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 					WillReturnRows(pgxmock.NewRows(rowsGetLogin).
 					AddRow(userId, username, email, pwHash))
 			},
-			ExpectedCookies: []*http.Cookie{},
 			ExpectedStatus:  http.StatusInternalServerError,
 			ExpectedError:   errors.Internal.JwtSecretMissingError.ErrorMsg,
 		},
@@ -1434,7 +1408,6 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 					WillReturnError(simulatedDbError)
 
 			},
-			ExpectedCookies: []*http.Cookie{},
 			ExpectedStatus:  http.StatusInternalServerError,
 			ExpectedJSON:    jsonSimulatedDbError,
 		},
@@ -1449,7 +1422,6 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 					WithArgs(username).
 					WillReturnError(simulatedDbError)
 			},
-			ExpectedCookies: []*http.Cookie{},
 			ExpectedStatus:  http.StatusInternalServerError,
 			ExpectedJSON:    jsonSimulatedDbError,
 		},
@@ -1466,7 +1438,6 @@ func TestAuthHandlerHandleLogin(t *testing.T) {
 
 				mock.ExpectExec(queryUpdateLastLogin).WithArgs(userId).WillReturnError(simulatedDbError)
 			},
-			ExpectedCookies: []*http.Cookie{},
 			ExpectedStatus:  http.StatusInternalServerError,
 			ExpectedJSON:    jsonSimulatedDbError,
 		},

--- a/Backend/internal/middleware/authentication_test.go
+++ b/Backend/internal/middleware/authentication_test.go
@@ -93,7 +93,7 @@ func TestAccessAuthenticated(t *testing.T) {
 		},
 		{
 			Name:               "Missing JWT secret",
-			AuthCookieValue:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiM2EyMmYxOS01ZjljLTRkY2MtOWU4Zi00NmU4NDUzNmRiMTAiLCJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyfQ.BDNt2077waOG_3l9Nd-pInTs30AAZ30z18KXB495HII",
+			AuthHeaderValue:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiM2EyMmYxOS01ZjljLTRkY2MtOWU4Zi00NmU4NDUzNmRiMTAiLCJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyfQ.BDNt2077waOG_3l9Nd-pInTs30AAZ30z18KXB495HII",
 			EnvJwtSecret:       "",
 			ExpectedStatusCode: http.StatusInternalServerError,
 			ExpectedBody: `{
@@ -106,7 +106,7 @@ func TestAccessAuthenticated(t *testing.T) {
 		},
 		{
 			Name:               "Invalid JWT token",
-			AuthCookieValue:    "invalid_jwt_token",
+			AuthHeaderValue:    "invalid_jwt_token",
 			EnvJwtSecret:       "test_secret",
 			ExpectedStatusCode: http.StatusInternalServerError,
 			ExpectedBody: `{
@@ -119,7 +119,7 @@ func TestAccessAuthenticated(t *testing.T) {
 		},
 		{
 			Name:               "Unexpected JWT signing method",
-			AuthCookieValue:    "eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.AbVUinMiT3J_03je8WTOIl-VdggzvoFgnOsdouAs-DLOtQzau9valrq-S6pETyi9Q18HH-EuwX49Q7m3KC0GuNBJAc9Tksulgsdq8GqwIqZqDKmG7hNmDzaQG1Dpdezn2qzv-otf3ZZe-qNOXUMRImGekfQFIuH_MjD2e8RZyww6lbZk",
+			AuthHeaderValue:    "eyJhbGciOiJFUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.AbVUinMiT3J_03je8WTOIl-VdggzvoFgnOsdouAs-DLOtQzau9valrq-S6pETyi9Q18HH-EuwX49Q7m3KC0GuNBJAc9Tksulgsdq8GqwIqZqDKmG7hNmDzaQG1Dpdezn2qzv-otf3ZZe-qNOXUMRImGekfQFIuH_MjD2e8RZyww6lbZk",
 			EnvJwtSecret:       "test_secret",
 			ExpectedStatusCode: http.StatusInternalServerError,
 			ExpectedBody: `{
@@ -132,7 +132,7 @@ func TestAccessAuthenticated(t *testing.T) {
 		},
 		{
 			Name:               "Subject missing",
-			AuthCookieValue:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyfQ.Ogb2idCPd36PAimIsia-7hLdmbVxqXFsP74YLQm9KqI",
+			AuthHeaderValue:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyfQ.Ogb2idCPd36PAimIsia-7hLdmbVxqXFsP74YLQm9KqI",
 			EnvJwtSecret:       "test_secret",
 			ExpectedStatusCode: http.StatusInternalServerError,
 			ExpectedBody: `{
@@ -145,7 +145,7 @@ func TestAccessAuthenticated(t *testing.T) {
 		},
 		{
 			Name:                 "Authorized access with valid JWT",
-			AuthCookieValue:      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiM2EyMmYxOS01ZjljLTRkY2MtOWU4Zi00NmU4NDUzNmRiMTAiLCJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyfQ.BDNt2077waOG_3l9Nd-pInTs30AAZ30z18KXB495HII",
+			AuthHeaderValue:      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiM2EyMmYxOS01ZjljLTRkY2MtOWU4Zi00NmU4NDUzNmRiMTAiLCJuYW1lIjoiSm9obiBEb2UiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyfQ.BDNt2077waOG_3l9Nd-pInTs30AAZ30z18KXB495HII",
 			EnvJwtSecret:         "test_secret",
 			ExpectedStatusCode:   http.StatusOK,
 			ExpectedBodyContains: "next handler called",

--- a/Backend/internal/util/testutil/bcrypt.go
+++ b/Backend/internal/util/testutil/bcrypt.go
@@ -14,8 +14,6 @@ type bcryptArgument struct {
 
 var bcryptHashPattern = regexp.MustCompile(`^\$2[ayb]\$.{56}$`)
 
-var expiresToleranceStr = `5s`
-
 func (b bcryptArgument) Match(arg interface{}) bool {
 	hash, ok := arg.(string)
 	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(b.expected))

--- a/Backend/internal/util/testutil/handler.go
+++ b/Backend/internal/util/testutil/handler.go
@@ -27,8 +27,6 @@ type HandlerTestDefinition struct {
 	ExpectedResponseFields map[string]string
 }
 
-var jwtPattern = regexp.MustCompile(`^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$`)
-
 func executeHandlerTest(t *testing.T, tt HandlerTestDefinition, handlerFunc func(rr http.ResponseWriter, req *http.Request), mock pgxmock.PgxPoolIface) {
 	tt.MockSetup(mock)
 

--- a/Backend/internal/util/testutil/middleware.go
+++ b/Backend/internal/util/testutil/middleware.go
@@ -21,7 +21,7 @@ type MiddlewareTestDefinition struct {
 	ExpectedStatusCode   int
 	ExpectedBody         string
 	ExpectedBodyContains string
-	AuthCookieValue      string
+	AuthHeaderValue      string
 	EnvJwtSecret         string
 }
 
@@ -39,11 +39,8 @@ func executeMiddlewareTest(t *testing.T, test MiddlewareTestDefinition, middlewa
 	req = req.WithContext(context.WithValue(req.Context(), util.TokenKey("token_user_id"), test.TokenUserId))
 	req.SetPathValue("id", test.IdPathParam)
 
-	if test.AuthCookieValue != "" {
-		req.AddCookie(&http.Cookie{
-			Name:  "magpie_auth",
-			Value: test.AuthCookieValue,
-		})
+	if test.AuthHeaderValue != "" {
+		req.Header.Add("Authorization", "Bearer "+test.AuthHeaderValue)
 	}
 
 	if test.EnvJwtSecret != "" {


### PR DESCRIPTION
### Description

This PR refactors the backend to provide the session token to the frontend rather than setting it as a cookie.
The reason for this is GDPR compliance.
The PR also updates the login flow and its unit tests.

Fixes #314

### Type of change

Please select the option that best describes the changes made:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Changes

- Removes cookie check from unit tests in preparation of refactoring
- Adds field requirement with regex to handler unit tests
- Refactors login route to return token instead of setting cookie
- Fixes linter errors
- Refactors auth middleware to accept bearer token from header instead of cookie
- Refactor middleware tests to use header instead of cookie
- Refactors auth handler to accept username or email for login
