### PR TITLE
Removes arm build test for Frontend, Backend Private and Backend Public

### DIFF
--- a/.github/workflows/backend-private-test.yaml
+++ b/.github/workflows/backend-private-test.yaml
@@ -184,6 +184,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image for arm64 and amd64
+      - name: Build Docker image for amd64
         run: |
-          docker buildx build --platform linux/amd64,linux/arm64 -t backend-private-test-image -f ./Backend/Dockerfile.private ./Backend
+          docker buildx build --platform linux/amd64 -t backend-private-test-image -f ./Backend/Dockerfile.private ./Backend

--- a/.github/workflows/backend-public-test.yaml
+++ b/.github/workflows/backend-public-test.yaml
@@ -184,6 +184,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image for arm64 and amd64
+      - name: Build Docker image for amd64
         run: |
-          docker buildx build --platform linux/amd64,linux/arm64 -t backend-public-test-image -f ./Backend/Dockerfile.public ./Backend
+          docker buildx build --platform linux/amd64 -t backend-public-test-image -f ./Backend/Dockerfile.public ./Backend

--- a/.github/workflows/frontend-test.yaml
+++ b/.github/workflows/frontend-test.yaml
@@ -40,6 +40,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image for arm64 and amd64
+      - name: Build Docker image for amd64
         run: |
-          docker buildx build --platform linux/amd64,linux/arm64 -t frontend-test-image ./Frontend
+          docker buildx build --platform linux/amd64 -t frontend-test-image ./Frontend


### PR DESCRIPTION
### Description

It was previously assumed that we'd be utilising platform specific libraries in our `backend` and `fronetend`. Insofar, this has not been the case.

As such, the `arm64` test is superfluous- and only increases the time it takes to run tests.

### Type of change

Please select the option that best describes the changes made:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
