### PR TITLE
Modifies docker-compose with pinned versions

### DIFF
--- a/Distribution/compose/remote/docker-compose.yaml
+++ b/Distribution/compose/remote/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
 
   private-service:
     image: ghcr.io/2024-cmpu9010-group-3/backend-private:0.9.1
-    container_name: private-backend
+    container_name: private-backend@sha256:2a3c392cccc99e6aac70f59d7d38133ad5ff22b2b28d1c3d5aa2a4041bd874f6
     depends_on:
       postgis-service:
         condition: service_healthy
@@ -37,7 +37,7 @@ services:
       - MAGPIE_CORS_ALLOWED_METHODS=GET POST PUT DELETE
 
   public-service:
-    image: ghcr.io/2024-cmpu9010-group-3/backend-public:0.9.1
+    image: ghcr.io/2024-cmpu9010-group-3/backend-public:0.9.1@sha256:ae3fa68f8a630e5d431bf7d027361ddb4bd97162284e89d0940ebfe01a45eb24
     container_name: public-backend
     depends_on:
       postgis-service:
@@ -54,7 +54,7 @@ services:
       - MAGPIE_CORS_ALLOWED_METHODS=GET POST PUT DELETE
 
   frontend-service:
-    image: ghcr.io/2024-cmpu9010-group-3/frontend:0.5.0
+    image: ghcr.io/2024-cmpu9010-group-3/frontend:0.5.0@sha256:81c9212f281aa0bfb9a15649d321bbe376074143977f5a0471b1a944affd3f01
     container_name: frontend
     depends_on:
       - private-service


### PR DESCRIPTION
### Description

This PR pins the container image with it's sha hash. This should fix the problem Kaustubh encountered earlier today.

### Type of change

Please select the option that best describes the changes made:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
