### PR TITLE
Implements workaround for race condition with login redirect

### DIFF
--- a/Frontend/src/app/components/form/login-form.tsx
+++ b/Frontend/src/app/components/form/login-form.tsx
@@ -29,10 +29,12 @@ export function LoginForm() {
     (async () => {
     if (sessionToken) {
       // if user is already logged in, redirect to home
-      router.push("/"); // redirect to home
+      setTimeout(() => {
+        router.push("/"); // redirect to home
+      }, 0);
     }
   })()
-  }, [router, sessionToken]);
+  }, [sessionToken, router]);
 
   const onSubmit = async (event: React.SyntheticEvent) => {
     event.preventDefault(); // prevent default form submission behavior
@@ -69,7 +71,9 @@ export function LoginForm() {
 
           setErrorMessage(null); // clear any error message
 
-          router.push("/")
+          setTimeout(() => {
+            router.push("/"); // redirect to home
+          }, 0);
 
         } else {
           setErrorMessage("Login failed: No user id received"); // if no user id, display error message


### PR DESCRIPTION
### Description

This PR is a workaround for what I believe to be a race condition between the redirect and setting the session token in the session context. I tested this on my machine; previously the login was very flaky and would not redirect ~75% of the time. With this fix, the redirect didn't fail once in over 20 tries with three different browsers.
But it remains to be seen if this will translate to the production environment.

Fixes #398 

### Type of change

Please select the option that best describes the changes made:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Changes

- Implements workaround for login redirect race condition
