### PR TITLE
Classification of spots found into public or private

### DIFF
--- a/Python/script/evaluate_empty_parking_detection/evaluate_empty_parking_detection.py
+++ b/Python/script/evaluate_empty_parking_detection/evaluate_empty_parking_detection.py
@@ -49,7 +49,7 @@ def create_mask(image_path, save_path, threshold=240):
     cv2.imwrite(save_path, mask_filtered)
 
 
-def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path, model):
+def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path, model, conf_threshold=0.45):
     """
     Detect cars in the image using the retrained YOLO model and draws them on the image.
 
@@ -57,7 +57,9 @@ def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path,
         image_path (str): Path of the image
         road_mask_path (str): Path of the saved mask
         output_image_path (str): Path to save the image with bounding boxes, red for parking and blue cars on the road
-        model : YOLO model.
+        model : YOLO model
+        conf_threshold (float): Minimum confidence threshold for a predictions to be considered, set at 0.354 the optimal value given by the f1 curve 
+
         
     Returns:
         detections_parking (list): List of the bounding boxes for the cars not on the road [x_center, y_center, width, height, angle_degrees]
@@ -80,6 +82,10 @@ def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path,
             x_center, y_center, width, height, angle_radians = map(float, box.xywhr[0])
             angle_degrees = angle_radians * (180 / math.pi) 
             cls = int(box.cls[0])
+            conf = float(box.conf[0])
+
+            if conf < conf_threshold:#we ignore the predictions that have a low confidance score as they are more likely to be misclassifications
+                continue
 
             if cls == 0:
                 if -45 <= angle_degrees <= 45 or 135 <= angle_degrees <= 225:

--- a/Python/script/evaluate_empty_parking_detection/evaluate_empty_parking_detection.py
+++ b/Python/script/evaluate_empty_parking_detection/evaluate_empty_parking_detection.py
@@ -49,7 +49,7 @@ def create_mask(image_path, save_path, threshold=240):
     cv2.imwrite(save_path, mask_filtered)
 
 
-def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path, model, conf_threshold=0.45):
+def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path, model, conf_threshold=0.4):
     """
     Detect cars in the image using the retrained YOLO model and draws them on the image.
 
@@ -58,8 +58,7 @@ def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path,
         road_mask_path (str): Path of the saved mask
         output_image_path (str): Path to save the image with bounding boxes, red for parking and blue cars on the road
         model : YOLO model
-        conf_threshold (float): Minimum confidence threshold for a predictions to be considered, set at 0.354 the optimal value given by the f1 curve 
-
+        conf_threshold (float): Minimum confidence threshold for a predictions to be considered
         
     Returns:
         detections_parking (list): List of the bounding boxes for the cars not on the road [x_center, y_center, width, height, angle_degrees]

--- a/Python/script/parking-detection/parking_detection.py
+++ b/Python/script/parking-detection/parking_detection.py
@@ -546,7 +546,7 @@ def classify_parking_spots(all_parking_spots, road_mask_path, center_long, cente
     road_mask = cv2.imread(road_mask_path, cv2.IMREAD_GRAYSCALE)
     road_contours, _ = cv2.findContours(road_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
 
-    print(center_long, center_lat)
+    #print(center_long, center_lat)
 
     for spot in all_parking_spots:
         x_center, y_center = convert_coordinates_to_bounding_box(spot[0], spot[1], center_long, center_lat)
@@ -561,7 +561,7 @@ def classify_parking_spots(all_parking_spots, road_mask_path, center_long, cente
         else:
             classification = "private"
 
-        print(classification)
+        #print(classification)
 
         classified_spots.append([spot[0], spot[1], classification])
 
@@ -578,7 +578,7 @@ def get_parking_coords_in_image(model, longitude, latitude):
         latitude (float): Latitude value
 
     Returns: 
-        all_detections (list): List of all coordinates of parking spots found in the image in the format log, lat, width, height, angle
+        all_detections (list): List of all coordinates of parking spots found in the image in the format long, lat, classification
     """
     output_folder = 'image_output'
     output_path_satelite_image = os.path.join(output_folder, f'{longitude}_{latitude}_satelite.png')
@@ -586,8 +586,8 @@ def get_parking_coords_in_image(model, longitude, latitude):
     output_path_mask_image = os.path.join(output_folder, f'{longitude}_{latitude}_mask.png')
     output_path_bb_image = os.path.join(output_folder, f'{longitude}_{latitude}_bounding_boxes.png')
 
-    #get_images(output_path_satelite_image, longitude, latitude, 'satellite-v9')
-    #get_images(output_path_road_image, longitude, latitude, 'streets-v12')
+    get_images(output_path_satelite_image, longitude, latitude, 'satellite-v9')
+    get_images(output_path_road_image, longitude, latitude, 'streets-v12')
 
     create_mask(output_path_road_image, output_path_mask_image)
     detections = detect_parking_spots_in_image(output_path_satelite_image, output_path_mask_image, output_path_bb_image, model)
@@ -732,7 +732,8 @@ if __name__ == "__main__":
     #main(-6.2563, 53.3952, -6.2525, 53.3974)#residential area
     #main(-6.289, 53.3653, -6.2842, 53.3681)#residential area
     #main(-6.2737, 53.3436, -6.2709, 53.3452)#urban area
-    main(-6.2751, 53.347, -6.272, 53.3489)#urban area
+    #main(-6.2751, 53.347, -6.272, 53.3489)#urban area
     #main(-6.2844, 53.3589, -6.2816, 53.3606)#residential area
     #main(-6.2901, 53.3587, -6.2872, 53.3604)#residential area
-    #main()
+
+    main()

--- a/Python/script/parking-detection/parking_detection.py
+++ b/Python/script/parking-detection/parking_detection.py
@@ -164,7 +164,7 @@ def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path,
         image_path (str): Path of the image
         road_mask_path (str): Path of the saved mask
         output_image_path (str): Path to save the image with bounding boxes, red for parking and blue cars on the road
-        model : YOLO model.
+        model : YOLO model
         conf_threshold (float): Minimum confidence threshold for a predictions to be considered, set at 0.354 the optimal value given by the f1 curve 
         
     Returns:
@@ -692,6 +692,7 @@ if __name__ == "__main__":
     #main(-6.289, 53.3653, -6.2842, 53.3681)#residential area
     #main(-6.2737, 53.3436, -6.2709, 53.3452)#urban area
     #main(-6.2751, 53.347, -6.272, 53.3489)#urban area
+    #main(-6.2844, 53.3589, -6.2816, 53.3606)#residential area
+    #main(-6.2901, 53.3587, -6.2872, 53.3604)#residential area
 
-    main(-6.2844, 53.3589, -6.2816, 53.3606)#residential area
-    main(-6.2901, 53.3587, -6.2872, 53.3604)#residential area
+    main()

--- a/Python/script/parking-detection/parking_detection.py
+++ b/Python/script/parking-detection/parking_detection.py
@@ -527,6 +527,44 @@ def draw_empty_spots_on_image_original(image_path, empty_spots, center_long, cen
     cv2.imwrite(image_path, image)
 
 
+def classify_parking_spots(all_parking_spots, road_mask_path, center_long, center_lat, threshold=15):
+    """
+    Classifies parking spots as public(on the street parking) or private(residential) based on their proximity to the road (calculated using the road mask)
+
+    Params:
+        all_parking_spots (list): List of all parking spots(by the model and then the empty parking detection) 
+        road_mask_path (string): Path to road mask
+        center_long (float): Longitude of the center of the image
+        center_lat (float): Latitude of the center of the image
+        threshold (int): Threshold in pixels to classify a spot near the road as public
+
+    Returns:
+        classified_spots (list): List of parking spots with classification added
+    """
+    classified_spots = []
+
+    road_mask = cv2.imread(road_mask_path, cv2.IMREAD_GRAYSCALE)
+    road_contours, _ = cv2.findContours(road_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+
+    for spot in all_parking_spots:
+        x_center, y_center = convert_coordinates_to_bounding_box(spot[0], spot[1], center_long, center_lat)
+
+        min_distance = float("inf")
+        for contour in road_contours:
+            distance = cv2.pointPolygonTest(contour, (x_center, y_center), measureDist=True)
+            min_distance = min(min_distance, abs(distance))
+
+        if min_distance <= threshold:
+            classification = "public"
+        else:
+            classification = "private"
+
+        print(classification)
+
+        classified_spots.append([spot[0], spot[1], classification])
+
+    return classified_spots
+
 def get_parking_coords_in_image(model, longitude, latitude):
     """
     Detects all the parking spaces in the image (at longitude/latitude) and returns a list of coordinates, agregating
@@ -546,8 +584,8 @@ def get_parking_coords_in_image(model, longitude, latitude):
     output_path_mask_image = os.path.join(output_folder, f'{longitude}_{latitude}_mask.png')
     output_path_bb_image = os.path.join(output_folder, f'{longitude}_{latitude}_bounding_boxes.png')
 
-    get_images(output_path_satelite_image, longitude, latitude, 'satellite-v9')
-    get_images(output_path_road_image, longitude, latitude, 'streets-v12')
+    #get_images(output_path_satelite_image, longitude, latitude, 'satellite-v9')
+    #get_images(output_path_road_image, longitude, latitude, 'streets-v12')
 
     create_mask(output_path_road_image, output_path_mask_image)
     detections = detect_parking_spots_in_image(output_path_satelite_image, output_path_mask_image, output_path_bb_image, model)
@@ -574,6 +612,7 @@ def get_parking_coords_in_image(model, longitude, latitude):
         draw_empty_spots_on_image_original(output_path_bb_image, empty_spots_filtered, longitude, latitude, avg_width_pixels, avg_length_pixels)
         empty_spots_coords = [spot for spot, _, _ in empty_spots_filtered]
         all_detections.extend(empty_spots_coords)
+        all_detections = classify_parking_spots(all_detections, output_path_mask_image, longitude, latitude)
 
     return all_detections
 
@@ -679,9 +718,9 @@ def main(top_left_longitude, top_left_latitude, bottom_right_longitude, bottom_r
     for long, lat in centers:
         detections = get_parking_coords_in_image(model, long, lat)
         for detection in detections:
-            all_detections.append([detection[0], detection[1]])
+            all_detections.append([detection[0], detection[1], detection[2]])
 
-    df = pd.DataFrame(all_detections, columns=["longitude", "latitude"])
+    df = pd.DataFrame(all_detections, columns=["longitude", "latitude", "type"])
     df = df.drop_duplicates(subset=["longitude", "latitude"], keep="first")# remove duplicate coords as there is potential overlap in the images
     df.to_csv(f"coordinates_in_{top_left_longitude}_{top_left_latitude}-{bottom_right_longitude}_{bottom_right_latitude}.csv", index=False)
     
@@ -692,7 +731,6 @@ if __name__ == "__main__":
     #main(-6.289, 53.3653, -6.2842, 53.3681)#residential area
     #main(-6.2737, 53.3436, -6.2709, 53.3452)#urban area
     #main(-6.2751, 53.347, -6.272, 53.3489)#urban area
-    #main(-6.2844, 53.3589, -6.2816, 53.3606)#residential area
-    #main(-6.2901, 53.3587, -6.2872, 53.3604)#residential area
-
-    main()
+    main(-6.2844, 53.3589, -6.2816, 53.3606)#residential area
+    main(-6.2901, 53.3587, -6.2872, 53.3604)#residential area
+    #main()

--- a/Python/script/parking-detection/parking_detection.py
+++ b/Python/script/parking-detection/parking_detection.py
@@ -156,7 +156,7 @@ def new_mask(image_path, save_path, threshold=240):
 
     cv2.imwrite(save_path, combined_mask)
 
-def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path, model, conf_threshold=0.45):
+def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path, model, conf_threshold=0.4):
     """
     Detect cars in the image using the retrained YOLO model and draws them on the image.
 
@@ -165,7 +165,7 @@ def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path,
         road_mask_path (str): Path of the saved mask
         output_image_path (str): Path to save the image with bounding boxes, red for parking and blue cars on the road
         model : YOLO model
-        conf_threshold (float): Minimum confidence threshold for a predictions to be considered, set at 0.354 the optimal value given by the f1 curve 
+        conf_threshold (float): Minimum confidence threshold for a predictions to be considered
         
     Returns:
         detections_parking (list): List of the bounding boxes for the cars not on the road [x_center, y_center, width, height, angle_degrees]

--- a/Python/script/parking-detection/parking_detection.py
+++ b/Python/script/parking-detection/parking_detection.py
@@ -527,7 +527,7 @@ def draw_empty_spots_on_image_original(image_path, empty_spots, center_long, cen
     cv2.imwrite(image_path, image)
 
 
-def classify_parking_spots(all_parking_spots, road_mask_path, center_long, center_lat, threshold=15):
+def classify_parking_spots(all_parking_spots, road_mask_path, center_long, center_lat, threshold=25):
     """
     Classifies parking spots as public(on the street parking) or private(residential) based on their proximity to the road (calculated using the road mask)
 
@@ -545,6 +545,8 @@ def classify_parking_spots(all_parking_spots, road_mask_path, center_long, cente
 
     road_mask = cv2.imread(road_mask_path, cv2.IMREAD_GRAYSCALE)
     road_contours, _ = cv2.findContours(road_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+
+    print(center_long, center_lat)
 
     for spot in all_parking_spots:
         x_center, y_center = convert_coordinates_to_bounding_box(spot[0], spot[1], center_long, center_lat)
@@ -730,7 +732,7 @@ if __name__ == "__main__":
     #main(-6.2563, 53.3952, -6.2525, 53.3974)#residential area
     #main(-6.289, 53.3653, -6.2842, 53.3681)#residential area
     #main(-6.2737, 53.3436, -6.2709, 53.3452)#urban area
-    #main(-6.2751, 53.347, -6.272, 53.3489)#urban area
-    main(-6.2844, 53.3589, -6.2816, 53.3606)#residential area
-    main(-6.2901, 53.3587, -6.2872, 53.3604)#residential area
+    main(-6.2751, 53.347, -6.272, 53.3489)#urban area
+    #main(-6.2844, 53.3589, -6.2816, 53.3606)#residential area
+    #main(-6.2901, 53.3587, -6.2872, 53.3604)#residential area
     #main()

--- a/Python/script/parking-detection/parking_detection.py
+++ b/Python/script/parking-detection/parking_detection.py
@@ -156,7 +156,7 @@ def new_mask(image_path, save_path, threshold=240):
 
     cv2.imwrite(save_path, combined_mask)
 
-def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path, model, conf_threshold=0.354):
+def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path, model, conf_threshold=0.45):
     """
     Detect cars in the image using the retrained YOLO model and draws them on the image.
 
@@ -546,8 +546,8 @@ def get_parking_coords_in_image(model, longitude, latitude):
     output_path_mask_image = os.path.join(output_folder, f'{longitude}_{latitude}_mask.png')
     output_path_bb_image = os.path.join(output_folder, f'{longitude}_{latitude}_bounding_boxes.png')
 
-    #get_images(output_path_satelite_image, longitude, latitude, 'satellite-v9')
-    #get_images(output_path_road_image, longitude, latitude, 'streets-v12')
+    get_images(output_path_satelite_image, longitude, latitude, 'satellite-v9')
+    get_images(output_path_road_image, longitude, latitude, 'streets-v12')
 
     create_mask(output_path_road_image, output_path_mask_image)
     detections = detect_parking_spots_in_image(output_path_satelite_image, output_path_mask_image, output_path_bb_image, model)
@@ -687,9 +687,11 @@ def main(top_left_longitude, top_left_latitude, bottom_right_longitude, bottom_r
     
 
 if __name__ == "__main__":
-    main(-6.2264, 53.4194, -6.2219, 53.4221)#parking lot
-    main(-6.2563, 53.3952, -6.2525, 53.3974)#residential area
-    main(-6.289, 53.3653, -6.2842, 53.3681)#residential area
-    main(-6.2737, 53.3436, -6.2709, 53.3452)#urban area
-    main(-6.2751, 53.347, -6.272, 53.3489)#urban area
-    #main()
+    #main(-6.2264, 53.4194, -6.2219, 53.4221)#parking lot
+    #main(-6.2563, 53.3952, -6.2525, 53.3974)#residential area
+    #main(-6.289, 53.3653, -6.2842, 53.3681)#residential area
+    #main(-6.2737, 53.3436, -6.2709, 53.3452)#urban area
+    #main(-6.2751, 53.347, -6.272, 53.3489)#urban area
+
+    main(-6.2844, 53.3589, -6.2816, 53.3606)#residential area
+    main(-6.2901, 53.3587, -6.2872, 53.3604)#residential area

--- a/Python/script/parking-detection/parking_detection_local.py
+++ b/Python/script/parking-detection/parking_detection_local.py
@@ -137,7 +137,7 @@ def new_mask(image_path, save_path, threshold=240):
     cv2.imwrite(save_path, combined_mask)
 
 
-def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path, model, conf_threshold=0.45):
+def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path, model, conf_threshold=0.4):
     """
     Detect cars in the image using the retrained YOLO model and draws them on the image.
 
@@ -146,7 +146,7 @@ def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path,
         road_mask_path (str): Path of the saved mask
         output_image_path (str): Path to save the image with bounding boxes, red for parking and blue cars on the road
         model : YOLO model
-        conf_threshold (float): Minimum confidence threshold for a predictions to be considered, set at 0.354 the optimal value given by the f1 curve 
+        conf_threshold (float): Minimum confidence threshold for a predictions to be considered
 
         
     Returns:

--- a/Python/script/parking-detection/parking_detection_local.py
+++ b/Python/script/parking-detection/parking_detection_local.py
@@ -398,10 +398,16 @@ def filter_empty_spots_on_road(empty_spots, road_mask_path, center_long, center_
     for spot, rotation, alignment in empty_spots:
         x_center, y_center = convert_coordinates_to_bounding_box(spot[0], spot[1], center_long, center_lat)
 
-        x_min = int(x_center - avg_spot_width / 2)
-        x_max = int(x_center + avg_spot_width / 2)
-        y_min = int(y_center - avg_spot_length / 2)
-        y_max = int(y_center + avg_spot_length / 2)
+        if alignment == 'horizontal':
+            x_min = int(x_center - avg_spot_width / 2)
+            x_max = int(x_center + avg_spot_width / 2)
+            y_min = int(y_center - avg_spot_length / 2)
+            y_max = int(y_center + avg_spot_length / 2)
+        else:
+            x_min = int(x_center - avg_spot_length / 2)
+            x_max = int(x_center + avg_spot_length / 2)
+            y_min = int(y_center - avg_spot_width / 2)
+            y_max = int(y_center + avg_spot_width / 2)
 
         car_region = road_mask[y_min:y_max, x_min:x_max]
         road_pixels = cv2.countNonZero(car_region)

--- a/Python/script/parking-detection/parking_detection_local.py
+++ b/Python/script/parking-detection/parking_detection_local.py
@@ -137,7 +137,7 @@ def new_mask(image_path, save_path, threshold=240):
     cv2.imwrite(save_path, combined_mask)
 
 
-def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path, model):
+def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path, model, conf_threshold=0.45):
     """
     Detect cars in the image using the retrained YOLO model and draws them on the image.
 
@@ -145,7 +145,9 @@ def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path,
         image_path (str): Path of the image
         road_mask_path (str): Path of the saved mask
         output_image_path (str): Path to save the image with bounding boxes, red for parking and blue cars on the road
-        model : YOLO model.
+        model : YOLO model
+        conf_threshold (float): Minimum confidence threshold for a predictions to be considered, set at 0.354 the optimal value given by the f1 curve 
+
         
     Returns:
         detections_parking (list): List of the bounding boxes for the cars not on the road [x_center, y_center, width, height, angle_degrees]
@@ -167,6 +169,10 @@ def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path,
             x_center, y_center, width, height, angle_radians = map(float, box.xywhr[0])
             angle_degrees = angle_radians * (180 / math.pi) 
             cls = int(box.cls[0])
+            conf = float(box.conf[0])
+
+            if conf < conf_threshold:#we ignore the predictions that have a low confidance score as they are more likely to be misclassifications
+                continue
 
             if cls == 0:
                 if -45 <= angle_degrees <= 45 or 135 <= angle_degrees <= 225:


### PR DESCRIPTION
### Description

Adds classification of spots as public(ex: on the street) or private(ex: residential)

Fixes #441 

### Type of change

Please select the option that best describes the changes made:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Changes

Adds classification of spots as public(ex: on the street) or private(ex: residential) based on an optimal threshold set to 25 pixels (distance to the road).
Fixes other issues in the parking detection scripts, such as adding the confidence interval for the model's predictions set at 0.4.
