### PR TITLE
Force update frontend package

### DIFF
--- a/Distribution/compose/remote/docker-compose.yaml
+++ b/Distribution/compose/remote/docker-compose.yaml
@@ -66,7 +66,7 @@ services:
       - MAGPIE_CORS_ALLOWED_METHODS=GET POST PUT DELETE
 
   frontend-service:
-    image: ghcr.io/2024-cmpu9010-group-3/frontend:0.9.0@sha256:7840177b3e46212185ed3d9bcdc15762d4e046cb5a32365f2b89dd95509d6f23
+    image: ghcr.io/2024-cmpu9010-group-3/frontend:0.9.0@sha256:a5ac7f847d42f023c47b09483b5371066ffd016e6c92ce51e949ba78e7883b3f
     container_name: frontend
     depends_on:
       private-service:

--- a/Distribution/kubernetes/Magpie/magpie/app/frontend/deployment.yaml
+++ b/Distribution/kubernetes/Magpie/magpie/app/frontend/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: frontend
-          image: ghcr.io/2024-cmpu9010-group-3/frontend:0.9.0@sha256:7840177b3e46212185ed3d9bcdc15762d4e046cb5a32365f2b89dd95509d6f23
+          image: ghcr.io/2024-cmpu9010-group-3/frontend:0.9.0@sha256:a5ac7f847d42f023c47b09483b5371066ffd016e6c92ce51e949ba78e7883b3f
           resources: {}
           ports:
             - containerPort: 3000


### PR DESCRIPTION
### Description

This PR updates the version of the frontend deployment because it wasn't automatically picked up by renovate.

### Type of change

Please select the option that best describes the changes made:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Changes

- Replaces frontend hash for remote compose and kubernetes deployment
