### PR TITLE
Adds parking zone, fixes highway misclassifications, adds angle alignment as criteria to avoid misclassifications

### DIFF
--- a/Python/script/add-parking-zone/add_parking_zone_to_csv.py
+++ b/Python/script/add-parking-zone/add_parking_zone_to_csv.py
@@ -1,5 +1,6 @@
 import geopandas as gpd
 import pandas as pd
+import matplotlib.pyplot as plt
 
 def main(parking_csv, zones_geojson):
     """
@@ -16,8 +17,14 @@ def main(parking_csv, zones_geojson):
 
     zones_gdf = gpd.read_file(zones_geojson)
 
-    zones_gdf = zones_gdf.to_crs(epsg=4326)
+    zones_gdf = zones_gdf.set_crs(epsg=4326)
     parking_gdf = parking_gdf.set_crs(epsg=4326)
+
+
+    print(parking_gdf.crs)
+    print(zones_gdf.crs)
+    print(zones_gdf.geometry.is_valid)
+
 
     if 'index_right' in parking_gdf.columns:
         parking_gdf = parking_gdf.drop(columns='index_right')
@@ -28,11 +35,33 @@ def main(parking_csv, zones_geojson):
 
     print(parking_with_zones.columns)
 
-    parking_with_zones['parking_zone'] = parking_with_zones['zone_left']
-    parking_with_zones['parking_zone_tarif'] = parking_with_zones['tarif_left']
+
+    fig, ax = plt.subplots(figsize=(10, 10))
+    zones_gdf.plot(ax=ax, color='lightblue', edgecolor='black', alpha=0.5)
+    parking_gdf.plot(ax=ax, color='red', markersize=5)
+    plt.show()
+
+    zones_gdf.plot(facecolor='lightblue', edgecolor='black', alpha=0.5)
+    plt.show()
+
+    base = zones_gdf.plot(facecolor='lightblue', edgecolor='black', alpha=0.5)
+    parking_gdf.plot(ax=base, color='red', markersize=10)
+    plt.show()
+
+
+
+    print("Parking Spots Bounding Box:")
+    print(parking_gdf.total_bounds)  # MinX, MinY, MaxX, MaxY for parking spots
+
+    print("Zones Bounding Box:")
+    print(zones_gdf.total_bounds) 
+
+    parking_with_zones['parking_zone'] = parking_with_zones['zone']
+    parking_with_zones['parking_zone_tarif'] = parking_with_zones['tarif']
 
     parking_with_zones.drop(columns='geometry', inplace=True)
     parking_with_zones.to_csv(parking_csv, index=False)
 
 if __name__ == "__main__":
-    main("coordinates_in_-6.2264_53.4194--6.2219_53.4221.csv", "tarif_zones.geojson")
+    main("coordinates_in_-6.3169_53.3767--6.3159_53.3773.csv", "tarif_zones.geojson")
+    #main("coordinates_in_-6.2708_53.3456--6.27_53.3459.csv", "tarif_zones.geojson")

--- a/Python/script/add-parking-zone/add_parking_zone_to_csv.py
+++ b/Python/script/add-parking-zone/add_parking_zone_to_csv.py
@@ -16,15 +16,8 @@ def main(parking_csv, zones_geojson):
     )
 
     zones_gdf = gpd.read_file(zones_geojson)
-
     zones_gdf = zones_gdf.set_crs(epsg=4326)
     parking_gdf = parking_gdf.set_crs(epsg=4326)
-
-
-    print(parking_gdf.crs)
-    print(zones_gdf.crs)
-    print(zones_gdf.geometry.is_valid)
-
 
     if 'index_right' in parking_gdf.columns:
         parking_gdf = parking_gdf.drop(columns='index_right')
@@ -33,35 +26,15 @@ def main(parking_csv, zones_geojson):
 
     parking_with_zones = gpd.sjoin(parking_gdf, zones_gdf, how="left", predicate="within")
 
-    print(parking_with_zones.columns)
+    #print(parking_with_zones.columns)
 
-
-    fig, ax = plt.subplots(figsize=(10, 10))
-    zones_gdf.plot(ax=ax, color='lightblue', edgecolor='black', alpha=0.5)
-    parking_gdf.plot(ax=ax, color='red', markersize=5)
-    plt.show()
-
-    zones_gdf.plot(facecolor='lightblue', edgecolor='black', alpha=0.5)
-    plt.show()
-
-    base = zones_gdf.plot(facecolor='lightblue', edgecolor='black', alpha=0.5)
-    parking_gdf.plot(ax=base, color='red', markersize=10)
-    plt.show()
-
-
-
-    print("Parking Spots Bounding Box:")
-    print(parking_gdf.total_bounds)  # MinX, MinY, MaxX, MaxY for parking spots
-
-    print("Zones Bounding Box:")
-    print(zones_gdf.total_bounds) 
-
-    parking_with_zones['parking_zone'] = parking_with_zones['zone']
-    parking_with_zones['parking_zone_tarif'] = parking_with_zones['tarif']
+    #fig, ax = plt.subplots(figsize=(10, 10))
+    #zones_gdf.plot(ax=ax, color='lightblue', edgecolor='black', alpha=0.5)
+    #parking_gdf.plot(ax=ax, color='red', markersize=5)
+    #plt.show()
 
     parking_with_zones.drop(columns='geometry', inplace=True)
     parking_with_zones.to_csv(parking_csv, index=False)
 
 if __name__ == "__main__":
-    main("coordinates_in_-6.3169_53.3767--6.3159_53.3773.csv", "tarif_zones.geojson")
-    #main("coordinates_in_-6.2708_53.3456--6.27_53.3459.csv", "tarif_zones.geojson")
+    main("coordinates_in_-6.2705_53.3466--6.2698_53.3468.csv", "tarif_zones.geojson") # replace with the final file name

--- a/Python/script/add-parking-zone/add_parking_zone_to_csv.py
+++ b/Python/script/add-parking-zone/add_parking_zone_to_csv.py
@@ -33,8 +33,11 @@ def main(parking_csv, zones_geojson):
     #parking_gdf.plot(ax=ax, color='red', markersize=5)
     #plt.show()
 
+    parking_with_zones['zone'] = parking_with_zones['zone'].fillna('blue') #for the rest of dublin outside of the areas covered in the geojson, the zone is blue
+    parking_with_zones['tarif'] = parking_with_zones['tarif'].fillna(0.80) # and the cost is 0.8
+
     parking_with_zones.drop(columns='geometry', inplace=True)
     parking_with_zones.to_csv(parking_csv, index=False)
 
 if __name__ == "__main__":
-    main("coordinates_in_-6.2705_53.3466--6.2698_53.3468.csv", "tarif_zones.geojson") # replace with the final file name
+    main("coordinates_in_-6.3072_53.4044--6.3031_53.4068.csv", "tarif_zones.geojson") # replace with the final file name

--- a/Python/script/add-parking-zone/add_parking_zone_to_csv.py
+++ b/Python/script/add-parking-zone/add_parking_zone_to_csv.py
@@ -1,0 +1,38 @@
+import geopandas as gpd
+import pandas as pd
+
+def main(parking_csv, zones_geojson):
+    """
+    Assigns the parking zones to the parking spots found 
+
+    Parameters:
+    parking_csv: Path to the csv file containing the parking spot coordinates
+    zones_geojson: Path to the geojson file containing the parking zones
+    """
+    parking_df = pd.read_csv(parking_csv)
+    parking_gdf = gpd.GeoDataFrame(
+        parking_df, geometry=gpd.points_from_xy(parking_df['longitude'], parking_df['latitude'])
+    )
+
+    zones_gdf = gpd.read_file(zones_geojson)
+
+    zones_gdf = zones_gdf.to_crs(epsg=4326)
+    parking_gdf = parking_gdf.set_crs(epsg=4326)
+
+    if 'index_right' in parking_gdf.columns:
+        parking_gdf = parking_gdf.drop(columns='index_right')
+    if 'index_right' in zones_gdf.columns:
+        zones_gdf = zones_gdf.drop(columns='index_right')
+
+    parking_with_zones = gpd.sjoin(parking_gdf, zones_gdf, how="left", predicate="within")
+
+    print(parking_with_zones.columns)
+
+    parking_with_zones['parking_zone'] = parking_with_zones['zone_left']
+    parking_with_zones['parking_zone_tarif'] = parking_with_zones['tarif_left']
+
+    parking_with_zones.drop(columns='geometry', inplace=True)
+    parking_with_zones.to_csv(parking_csv, index=False)
+
+if __name__ == "__main__":
+    main("coordinates_in_-6.2264_53.4194--6.2219_53.4221.csv", "tarif_zones.geojson")

--- a/Python/script/evaluate_empty_parking_detection/evaluate_empty_parking_detection.py
+++ b/Python/script/evaluate_empty_parking_detection/evaluate_empty_parking_detection.py
@@ -33,8 +33,13 @@ def create_mask(image_path, save_path, threshold=240):
 
     orange_mask = cv2.inRange(img_hsv, lower_orange, upper_orange)
     yellow_mask = cv2.inRange(img_hsv, lower_yellow, upper_yellow)
-    combined_mask = cv2.bitwise_or(road_mask, orange_mask)
-    combined_mask = cv2.bitwise_or(combined_mask, yellow_mask)
+
+    dilation_kernel = np.ones((15, 15), np.uint8)#we thicken the road width for highways as the road doesn't take into account the multiple lanes (to reduce misclassifications)
+    orange_mask_dilated = cv2.dilate(orange_mask, dilation_kernel, iterations=2)
+    yellow_mask_dilated = cv2.dilate(yellow_mask, dilation_kernel, iterations=2)
+
+    combined_mask = cv2.bitwise_or(road_mask, orange_mask_dilated)
+    combined_mask = cv2.bitwise_or(combined_mask, yellow_mask_dilated)
 
     kernel = np.ones((2, 2), np.uint8)#use smaller kernel as it works better
     combined_mask = cv2.morphologyEx(combined_mask, cv2.MORPH_CLOSE, kernel)#cv2.MORPH_CLOSE actually works better

--- a/Python/script/evaluate_empty_parking_detection/evaluate_empty_parking_detection.py
+++ b/Python/script/evaluate_empty_parking_detection/evaluate_empty_parking_detection.py
@@ -263,13 +263,6 @@ def detect_empty_spots(cars, avg_spot_width, avg_spot_length, avg_width_pixels, 
             angle_radians = math.atan2(y_next - y_current, x_next - x_current)
             angle_degrees = math.degrees(angle_radians)
 
-            if alignment == "horizontal":
-                angle_current = angle_current % 180
-                angle_next = angle_next % 180
-            elif alignment == "vertical":
-                angle_current = (angle_current - 90) % 180
-                angle_next = (angle_next - 90) % 180
-
             angle_deviation = abs(angle_current - angle_next)
             angle_deviation = min(angle_deviation, 360 - angle_deviation)
 

--- a/Python/script/evaluate_empty_parking_detection/evaluate_empty_parking_detection.py
+++ b/Python/script/evaluate_empty_parking_detection/evaluate_empty_parking_detection.py
@@ -238,10 +238,8 @@ def detect_empty_spots(cars, avg_spot_width, avg_spot_length, avg_width_pixels, 
     """
     empty_spots = []
     
-    #horizontal_cars_sorted_by_long = sorted([car for car in cars if car[5] == 'horizontal'], key=lambda point: point[0]) 
     horizontal_cars_sorted_by_lat = sorted([car for car in cars if car[5] == 'horizontal'], key=lambda point: point[1])
     vertical_cars_sorted_by_long = sorted([car for car in cars if car[5] == 'vertical'], key=lambda point: point[0])  
-    #vertical_cars_sorted_by_lat = sorted([car for car in cars if car[5] == 'vertical'], key=lambda point: point[1]) 
 
     def find_empty_spots(sorted_cars, alignment, gap_dimension, gap_threshold_meters):
         """ Detects empty spots in the sorted list of cars for a specific alignment (horizontal or vertical) 
@@ -278,9 +276,7 @@ def detect_empty_spots(cars, avg_spot_width, avg_spot_length, avg_width_pixels, 
                     empty_spots.append((empty_x_center, empty_y_center, avg_width_pixels, avg_length_pixels, angle_degrees, alignment))
                     print(f"Empty parking spot at {empty_x_center}, {empty_y_center}")
 
-    #find_empty_spots(horizontal_cars_sorted_by_long, 'horizontal', avg_spot_length, gap_threshold_meters=9) #Horizontal spots stacked in a column
     find_empty_spots(horizontal_cars_sorted_by_lat, 'horizontal', avg_spot_width, gap_threshold_meters) #Horizontal spots in a row
-    #find_empty_spots(vertical_cars_sorted_by_lat, 'vertical', avg_spot_length, gap_threshold_meters=9) # Vertical spots side by side in a row
     find_empty_spots(vertical_cars_sorted_by_long, 'vertical', avg_spot_width, gap_threshold_meters)  #Vertical spots in columns
 
     empty_spots = sorted(empty_spots, key=lambda spot: (spot[0], spot[1]))

--- a/Python/script/evaluate_empty_parking_detection/evaluate_empty_parking_detection.py
+++ b/Python/script/evaluate_empty_parking_detection/evaluate_empty_parking_detection.py
@@ -238,10 +238,10 @@ def detect_empty_spots(cars, avg_spot_width, avg_spot_length, avg_width_pixels, 
     """
     empty_spots = []
     
-    horizontal_cars_sorted_by_long = sorted([car for car in cars if car[5] == 'horizontal'], key=lambda point: point[0]) 
+    #horizontal_cars_sorted_by_long = sorted([car for car in cars if car[5] == 'horizontal'], key=lambda point: point[0]) 
     horizontal_cars_sorted_by_lat = sorted([car for car in cars if car[5] == 'horizontal'], key=lambda point: point[1])
     vertical_cars_sorted_by_long = sorted([car for car in cars if car[5] == 'vertical'], key=lambda point: point[0])  
-    vertical_cars_sorted_by_lat = sorted([car for car in cars if car[5] == 'vertical'], key=lambda point: point[1]) 
+    #vertical_cars_sorted_by_lat = sorted([car for car in cars if car[5] == 'vertical'], key=lambda point: point[1]) 
 
     def find_empty_spots(sorted_cars, alignment, gap_dimension, gap_threshold_meters):
         """ Detects empty spots in the sorted list of cars for a specific alignment (horizontal or vertical) 
@@ -253,8 +253,8 @@ def detect_empty_spots(cars, avg_spot_width, avg_spot_length, avg_width_pixels, 
         gap_threshold_meters (float): Maximum allowed gap to consider there is an empty parking spot or multiple parking spots
         """
         for i in range(len(sorted_cars) - 1):
-            x_current, y_current, _, _, _, _ = sorted_cars[i]
-            x_next, y_next, _, _, _, _ = sorted_cars[i + 1]
+            x_current, y_current, _, _, angle_current, _ = sorted_cars[i]
+            x_next, y_next, _, _, angle_next, _ = sorted_cars[i + 1]
 
             gap_distance = geodesic((y_current, x_current), (y_next, x_next)).meters
             avg_half_dim = gap_dimension / 2
@@ -262,6 +262,19 @@ def detect_empty_spots(cars, avg_spot_width, avg_spot_length, avg_width_pixels, 
 
             angle_radians = math.atan2(y_next - y_current, x_next - x_current)
             angle_degrees = math.degrees(angle_radians)
+
+            if alignment == "horizontal":
+                angle_current = angle_current % 180
+                angle_next = angle_next % 180
+            elif alignment == "vertical":
+                angle_current = (angle_current - 90) % 180
+                angle_next = (angle_next - 90) % 180
+
+            angle_deviation = abs(angle_current - angle_next)
+            angle_deviation = min(angle_deviation, 360 - angle_deviation)
+
+            if angle_deviation > 35:
+                continue
             
             if adjusted_gap <= gap_threshold_meters and adjusted_gap > gap_dimension:
                 num_spots = int(adjusted_gap // gap_dimension)
@@ -272,10 +285,10 @@ def detect_empty_spots(cars, avg_spot_width, avg_spot_length, avg_width_pixels, 
                     empty_spots.append((empty_x_center, empty_y_center, avg_width_pixels, avg_length_pixels, angle_degrees, alignment))
                     print(f"Empty parking spot at {empty_x_center}, {empty_y_center}")
 
-    find_empty_spots(horizontal_cars_sorted_by_long, 'horizontal', avg_spot_length, gap_threshold_meters) #Horizontal spots in a row
-    find_empty_spots(horizontal_cars_sorted_by_lat, 'horizontal', avg_spot_width, gap_threshold_meters=9 ) #Horizontal spots stacked in a column
-    find_empty_spots(vertical_cars_sorted_by_lat, 'vertical', avg_spot_length, gap_threshold_meters) #Vertical spots in columns
-    find_empty_spots(vertical_cars_sorted_by_long, 'vertical', avg_spot_width, gap_threshold_meters=9)  # Vertical spots side by side in a row
+    #find_empty_spots(horizontal_cars_sorted_by_long, 'horizontal', avg_spot_length, gap_threshold_meters=9) #Horizontal spots stacked in a column
+    find_empty_spots(horizontal_cars_sorted_by_lat, 'horizontal', avg_spot_width, gap_threshold_meters) #Horizontal spots in a row
+    #find_empty_spots(vertical_cars_sorted_by_lat, 'vertical', avg_spot_length, gap_threshold_meters=9) # Vertical spots side by side in a row
+    find_empty_spots(vertical_cars_sorted_by_long, 'vertical', avg_spot_width, gap_threshold_meters)  #Vertical spots in columns
 
     empty_spots = sorted(empty_spots, key=lambda spot: (spot[0], spot[1]))
     unique_empty_spots = []

--- a/Python/script/parking-detection/parking_detection.py
+++ b/Python/script/parking-detection/parking_detection.py
@@ -99,8 +99,13 @@ def create_mask(image_path, save_path, threshold=240):
 
     orange_mask = cv2.inRange(img_hsv, lower_orange, upper_orange)
     yellow_mask = cv2.inRange(img_hsv, lower_yellow, upper_yellow)
-    combined_mask = cv2.bitwise_or(road_mask, orange_mask)
-    combined_mask = cv2.bitwise_or(combined_mask, yellow_mask)
+
+    dilation_kernel = np.ones((10, 10), np.uint8)#we thicken the road width for highways as the road doesn't take into account the multiple lanes (to reduce misclassifications)
+    orange_mask_dilated = cv2.dilate(orange_mask, dilation_kernel, iterations=1)
+    yellow_mask_dilated = cv2.dilate(yellow_mask, dilation_kernel, iterations=1)
+
+    combined_mask = cv2.bitwise_or(road_mask, orange_mask_dilated)
+    combined_mask = cv2.bitwise_or(combined_mask, yellow_mask_dilated)
 
     kernel = np.ones((2, 2), np.uint8)#use smaller kernel as it works better
     combined_mask = cv2.morphologyEx(combined_mask, cv2.MORPH_CLOSE, kernel)#cv2.MORPH_CLOSE actually works better
@@ -646,8 +651,8 @@ def get_parking_coords_in_image(model, longitude, latitude):
     output_path_mask_image = os.path.join(output_folder, f'{longitude}_{latitude}_mask.png')
     output_path_bb_image = os.path.join(output_folder, f'{longitude}_{latitude}_bounding_boxes.png')
 
-    get_images(output_path_satelite_image, longitude, latitude, 'satellite-v9')
-    get_images(output_path_road_image, longitude, latitude, 'streets-v12')
+    #get_images(output_path_satelite_image, longitude, latitude, 'satellite-v9')
+    #get_images(output_path_road_image, longitude, latitude, 'streets-v12')
 
     create_mask(output_path_road_image, output_path_mask_image)
     detections = detect_parking_spots_in_image(output_path_satelite_image, output_path_mask_image, output_path_bb_image, model)
@@ -800,5 +805,12 @@ if __name__ == "__main__":
     #main(-6.2754, 53.3471, -6.2732, 53.3483)#urban area
     #main(-6.2652, 53.3525, -6.2625, 53.3541)#urban with parking lot
 
-    main()
+    main(-6.3818, 53.3315, -6.3808, 53.3321)
+    main(-6.3828, 53.3326, -6.3818, 53.3332)
+    main(-6.3906, 53.3558, -6.3895, 53.3564)
+    main(-6.2374, 53.3692, -6.2364, 53.3698)
+    main(-6.2422, 53.3719, -6.2412, 53.3725)
+    main(-6.2301, 53.4097, -6.2269, 53.4115)
+
+    #main()
 

--- a/Python/script/parking-detection/parking_detection.py
+++ b/Python/script/parking-detection/parking_detection.py
@@ -370,13 +370,6 @@ def detect_empty_spots(cars, avg_spot_width, avg_spot_length, gap_threshold_mete
             angle_radians = math.atan2(y_next - y_current, x_next - x_current)
             angle_degrees = math.degrees(angle_radians)
 
-            if alignment == "horizontal":
-                angle_current = angle_current % 180
-                angle_next = angle_next % 180
-            elif alignment == "vertical":
-                angle_current = (angle_current - 90) % 180
-                angle_next = (angle_next - 90) % 180
-
             angle_deviation = abs(angle_current - angle_next)
             angle_deviation = min(angle_deviation, 360 - angle_deviation)
 

--- a/Python/script/parking-detection/parking_detection.py
+++ b/Python/script/parking-detection/parking_detection.py
@@ -100,7 +100,7 @@ def create_mask(image_path, save_path, threshold=240):
     orange_mask = cv2.inRange(img_hsv, lower_orange, upper_orange)
     yellow_mask = cv2.inRange(img_hsv, lower_yellow, upper_yellow)
 
-    dilation_kernel = np.ones((10, 10), np.uint8)#we thicken the road width for highways as the road doesn't take into account the multiple lanes (to reduce misclassifications)
+    dilation_kernel = np.ones((15, 15), np.uint8)#we thicken the road width for highways as the road doesn't take into account the multiple lanes (to reduce misclassifications)
     orange_mask_dilated = cv2.dilate(orange_mask, dilation_kernel, iterations=1)
     yellow_mask_dilated = cv2.dilate(yellow_mask, dilation_kernel, iterations=1)
 

--- a/Python/script/parking-detection/parking_detection.py
+++ b/Python/script/parking-detection/parking_detection.py
@@ -100,9 +100,9 @@ def create_mask(image_path, save_path, threshold=240):
     orange_mask = cv2.inRange(img_hsv, lower_orange, upper_orange)
     yellow_mask = cv2.inRange(img_hsv, lower_yellow, upper_yellow)
 
-    dilation_kernel = np.ones((15, 15), np.uint8)#we thicken the road width for highways as the road doesn't take into account the multiple lanes (to reduce misclassifications)
-    orange_mask_dilated = cv2.dilate(orange_mask, dilation_kernel, iterations=1)
-    yellow_mask_dilated = cv2.dilate(yellow_mask, dilation_kernel, iterations=1)
+    dilation_kernel = np.ones((10, 10), np.uint8)#we thicken the road width for highways as the road doesn't take into account the multiple lanes (to reduce misclassifications)
+    orange_mask_dilated = cv2.dilate(orange_mask, dilation_kernel, iterations=2)
+    yellow_mask_dilated = cv2.dilate(yellow_mask, dilation_kernel, iterations=2)
 
     combined_mask = cv2.bitwise_or(road_mask, orange_mask_dilated)
     combined_mask = cv2.bitwise_or(combined_mask, yellow_mask_dilated)

--- a/Python/script/parking-detection/parking_detection.py
+++ b/Python/script/parking-detection/parking_detection.py
@@ -345,10 +345,10 @@ def detect_empty_spots(cars, avg_spot_width, avg_spot_length, gap_threshold_mete
     """
     empty_spots = []
     
-    horizontal_cars_sorted_by_long = sorted([car for car in cars if car[5] == 'horizontal'], key=lambda point: point[0]) 
+    #horizontal_cars_sorted_by_long = sorted([car for car in cars if car[5] == 'horizontal'], key=lambda point: point[0]) 
     horizontal_cars_sorted_by_lat = sorted([car for car in cars if car[5] == 'horizontal'], key=lambda point: point[1])
     vertical_cars_sorted_by_long = sorted([car for car in cars if car[5] == 'vertical'], key=lambda point: point[0])  
-    vertical_cars_sorted_by_lat = sorted([car for car in cars if car[5] == 'vertical'], key=lambda point: point[1]) 
+    #vertical_cars_sorted_by_lat = sorted([car for car in cars if car[5] == 'vertical'], key=lambda point: point[1]) 
 
     def find_empty_spots(sorted_cars, alignment, gap_dimension, gap_threshold_meters):
         """ Detects empty spots in the sorted list of cars for a specific alignment (horizontal or vertical) 
@@ -380,7 +380,7 @@ def detect_empty_spots(cars, avg_spot_width, avg_spot_length, gap_threshold_mete
             angle_deviation = abs(angle_current - angle_next)
             angle_deviation = min(angle_deviation, 360 - angle_deviation)
 
-            if angle_deviation > 15:
+            if angle_deviation > 35:
                 continue
             
             if adjusted_gap <= gap_threshold_meters and adjusted_gap > gap_dimension:

--- a/Python/script/parking-detection/parking_detection.py
+++ b/Python/script/parking-detection/parking_detection.py
@@ -100,7 +100,7 @@ def create_mask(image_path, save_path, threshold=240):
     orange_mask = cv2.inRange(img_hsv, lower_orange, upper_orange)
     yellow_mask = cv2.inRange(img_hsv, lower_yellow, upper_yellow)
 
-    dilation_kernel = np.ones((10, 10), np.uint8)#we thicken the road width for highways as the road doesn't take into account the multiple lanes (to reduce misclassifications)
+    dilation_kernel = np.ones((15, 15), np.uint8)#we thicken the road width for highways as the road doesn't take into account the multiple lanes (to reduce misclassifications)
     orange_mask_dilated = cv2.dilate(orange_mask, dilation_kernel, iterations=2)
     yellow_mask_dilated = cv2.dilate(yellow_mask, dilation_kernel, iterations=2)
 

--- a/Python/script/parking-detection/parking_detection.py
+++ b/Python/script/parking-detection/parking_detection.py
@@ -345,10 +345,8 @@ def detect_empty_spots(cars, avg_spot_width, avg_spot_length, gap_threshold_mete
     """
     empty_spots = []
     
-    #horizontal_cars_sorted_by_long = sorted([car for car in cars if car[5] == 'horizontal'], key=lambda point: point[0]) 
     horizontal_cars_sorted_by_lat = sorted([car for car in cars if car[5] == 'horizontal'], key=lambda point: point[1])
     vertical_cars_sorted_by_long = sorted([car for car in cars if car[5] == 'vertical'], key=lambda point: point[0])  
-    #vertical_cars_sorted_by_lat = sorted([car for car in cars if car[5] == 'vertical'], key=lambda point: point[1]) 
 
     def find_empty_spots(sorted_cars, alignment, gap_dimension, gap_threshold_meters):
         """ Detects empty spots in the sorted list of cars for a specific alignment (horizontal or vertical) 
@@ -385,9 +383,7 @@ def detect_empty_spots(cars, avg_spot_width, avg_spot_length, gap_threshold_mete
                     empty_spots.append(([empty_x_center, empty_y_center], angle_degrees, alignment))
                     print(f"Empty parking spot at {empty_x_center}, {empty_y_center}")
 
-    #find_empty_spots(horizontal_cars_sorted_by_long, 'horizontal', avg_spot_length, gap_threshold_meters=9) #Horizontal spots stacked in a column
     find_empty_spots(horizontal_cars_sorted_by_lat, 'horizontal', avg_spot_width, gap_threshold_meters) #Horizontal spots in a row
-    #find_empty_spots(vertical_cars_sorted_by_lat, 'vertical', avg_spot_length, gap_threshold_meters=9) # Vertical spots side by side in a row
     find_empty_spots(vertical_cars_sorted_by_long, 'vertical', avg_spot_width, gap_threshold_meters)  #Vertical spots in columns
 
     empty_spots = sorted(empty_spots, key=lambda spot: (spot[0][0], spot[0][1]))
@@ -686,7 +682,7 @@ def get_parking_coords_in_image(model, longitude, latitude):
         empty_spots_coords = [spot for spot, _, _ in empty_spots_filtered]
         all_detections.extend(empty_spots_coords)
         all_detections, cluster_labels = classify_parking_spots(all_detections, output_path_mask_image, longitude, latitude)
-        #draw_clusters_and_labels(output_path_bb_image, all_detections, cluster_labels, longitude, latitude)
+        draw_clusters_and_labels(output_path_bb_image, all_detections, cluster_labels, longitude, latitude)
 
     return all_detections
 
@@ -810,13 +806,6 @@ if __name__ == "__main__":
     main(-6.2859, 53.3636, -6.2823, 53.3656)#residential area
     main(-6.2754, 53.3471, -6.2732, 53.3483)#urban area
     main(-6.2652, 53.3525, -6.2625, 53.3541)#urban with parking lot
-
-    '''main(-6.3818, 53.3315, -6.3808, 53.3321)
-    main(-6.3828, 53.3326, -6.3818, 53.3332)
-    main(-6.3906, 53.3558, -6.3895, 53.3564)
-    main(-6.2374, 53.3692, -6.2364, 53.3698)
-    main(-6.2422, 53.3719, -6.2412, 53.3725)
-    main(-6.2301, 53.4097, -6.2269, 53.4115)'''
 
     #main()
 

--- a/Python/script/parking-detection/parking_detection_local.py
+++ b/Python/script/parking-detection/parking_detection_local.py
@@ -12,50 +12,6 @@ from geopy.distance import geodesic
 from sklearn.cluster import DBSCAN
 
 
-def create_mask_using_canny(image_path, save_path, low_threshold=50, high_threshold=200):
-   """
-    Creates and saves a binary mask from the mapbox image of the road (Mapbox Streets) using Canny edge detction
-    Gives worse results than the original and previous mask as there are too many edges interfering with the road
-
-    Params:
-        image_path (str): Path of the image
-        save_path (str): Path to save the mask
-        low_threshold (int): Lower threshold for Canny edge detection
-        high_threshold (int): Upper threshold for Canny edge detection
-    """
-   img = cv2.imread(image_path)
-   img_gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
-   _, road_mask = cv2.threshold(img_gray, 240, 255, cv2.THRESH_BINARY)
-
-   img_hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
-   lower_orange = np.array([10, 100, 100])
-   upper_orange = np.array([25, 255, 255])
-   lower_yellow = np.array([25, 100, 100])
-   upper_yellow = np.array([35, 255, 255])
-
-   orange_mask = cv2.inRange(img_hsv, lower_orange, upper_orange)
-   yellow_mask = cv2.inRange(img_hsv, lower_yellow, upper_yellow)
-   combined_mask = cv2.bitwise_or(road_mask, orange_mask)
-   combined_mask = cv2.bitwise_or(combined_mask, yellow_mask)
-
-   masked_img = cv2.bitwise_and(img_gray, img_gray, mask=combined_mask)
-   edges = cv2.Canny(masked_img, low_threshold, high_threshold)
-
-   kernel = np.ones((3, 3), np.uint8)
-   edges_cleaned = cv2.dilate(edges, kernel, iterations=1)
-   edges_cleaned = cv2.erode(edges_cleaned, kernel, iterations=1)
-   edges_cleaned = cv2.morphologyEx(edges_cleaned, cv2.MORPH_CLOSE, kernel)
-
-   contours, _ = cv2.findContours(edges_cleaned, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-   mask_filtered = np.zeros_like(edges)
-
-   for contour in contours:
-        if cv2.contourArea(contour) > 50: 
-            cv2.drawContours(mask_filtered, [contour], -1, 255, thickness=cv2.FILLED)
-
-   cv2.imwrite(save_path, mask_filtered)
-
-
 def create_mask(image_path, save_path, threshold=240):
     """
     Creates and saves a binary mask from the mapbox image of the road (Mapbox Streets).
@@ -80,8 +36,13 @@ def create_mask(image_path, save_path, threshold=240):
 
     orange_mask = cv2.inRange(img_hsv, lower_orange, upper_orange)
     yellow_mask = cv2.inRange(img_hsv, lower_yellow, upper_yellow)
-    combined_mask = cv2.bitwise_or(road_mask, orange_mask)
-    combined_mask = cv2.bitwise_or(combined_mask, yellow_mask)
+
+    dilation_kernel = np.ones((15, 15), np.uint8)#we thicken the road width for highways as the road doesn't take into account the multiple lanes (to reduce misclassifications)
+    orange_mask_dilated = cv2.dilate(orange_mask, dilation_kernel, iterations=2)
+    yellow_mask_dilated = cv2.dilate(yellow_mask, dilation_kernel, iterations=2)
+
+    combined_mask = cv2.bitwise_or(road_mask, orange_mask_dilated)
+    combined_mask = cv2.bitwise_or(combined_mask, yellow_mask_dilated)
 
     kernel = np.ones((2, 2), np.uint8)#use smaller kernel as it works better
     combined_mask = cv2.morphologyEx(combined_mask, cv2.MORPH_CLOSE, kernel)#cv2.MORPH_CLOSE actually works better
@@ -94,51 +55,6 @@ def create_mask(image_path, save_path, threshold=240):
             cv2.drawContours(mask_filtered, [contour], -1, 255, thickness=cv2.FILLED)
 
     cv2.imwrite(save_path, mask_filtered)
-
-def old_mask(image_path, save_path, threshold=240):
-    """
-    Creates and saves a binary mask from the mapbox image of the road (Mapbox Streets). The roads are in white while the rest of the image is darker
-    Initial mask, that doesn't remove the street names
-
-    Params:
-        image_path (str): Path of the image
-        save_path (str): Path to save the mask
-        threshold (int): Threshold to differentiate the road from the areas outside of the road
-    """
-    img = cv2.imread(image_path)
-    img_gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
-
-    _, road_mask = cv2.threshold(img_gray, threshold, 255, cv2.THRESH_BINARY)
-    cv2.imwrite(save_path, road_mask)
-
-def new_mask(image_path, save_path, threshold=240):
-    """
-    Creates and saves a binary mask from the mapbox image of the road (Mapbox Streets).
-    The roads are in white and some additional roads are in orange/yellow (highways/ roads with more lanes).
-
-    Params:
-        image_path (str): Path of the image
-        save_path (str): Path to save the mask
-        threshold (int): Threshold to differentiate the road from the areas outside of the road
-    """
-    img = cv2.imread(image_path)
-    img_gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
-    _, road_mask = cv2.threshold(img_gray, threshold, 255, cv2.THRESH_BINARY)
-
-    img_hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
-    lower_orange = np.array([10, 100, 100])
-    upper_orange = np.array([25, 255, 255])
-    lower_yellow = np.array([25, 100, 100])
-    upper_yellow = np.array([35, 255, 255])
-
-    orange_mask = cv2.inRange(img_hsv, lower_orange, upper_orange)
-    yellow_mask = cv2.inRange(img_hsv, lower_yellow, upper_yellow)
-
-    combined_mask = cv2.bitwise_or(road_mask, orange_mask)
-    combined_mask = cv2.bitwise_or(combined_mask, yellow_mask)
-
-    cv2.imwrite(save_path, combined_mask)
-
 
 def detect_parking_spots_in_image(image_path, road_mask_path, output_image_path, model, conf_threshold=0.4):
     """


### PR DESCRIPTION
### Description

Adds parking zone, fixes highway misclassifications, adds angle alignment as criteria to avoid misclassifications

Fixes #482 #468 

### Type of change

Please select the option that best describes the changes made:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Changes

Adds a new script add_parking_zone_to_csv which adds the parking zone color and cost for each parking spot detected.
Modifies road mask to make orange/yellow roads larger (highways) to avoid misclassifications.
Empty parking spot detection now focusses on 2 cases, and uses the angle of alignment between current and next to avoid misclassifications.