### PR TITLE
Enables SVGs and D2 in the devcontainer

### DIFF
--- a/Documentation/.devcontainer/Dockerfile
+++ b/Documentation/.devcontainer/Dockerfile
@@ -1,1 +1,13 @@
 FROM qmcgaw/latexdevcontainer:latest-full@sha256:4932d0d062665156f0b08ec963a80dcda94b17fa33c8b1fa7ae667dbf91d5c65
+
+# Install additional packages
+RUN apt update && apt install -y \
+    make \
+    curl \
+    inkscape \
+    libdrm2 \
+    libgbm1 \
+    libasound2
+
+# Install d2lang
+RUN curl -fsSL https://d2lang.com/install.sh | sh -s --

--- a/Documentation/.devcontainer/devcontainer.json
+++ b/Documentation/.devcontainer/devcontainer.json
@@ -20,6 +20,9 @@
                 "shardulm94.trailing-spaces",
                 "streetsidesoftware.code-spell-checker", // spell checker
                 "stkb.rewrap", // rewrap comments after n characters on one line
+                // D2
+                "terrastruct.d2",
+                "awtnb.d2-arrow",
                 // Other
                 "vscode-icons-team.vscode-icons"
             ],
@@ -38,8 +41,24 @@
                 "files.associations": {
                     "*.tex": "latex"
                 },
-                "latex-workshop.latexindent.path": "latexindent",
-                "latex-workshop.latexindent.args": [
+                "latex-workshop.latex.tools": [
+                    {
+                        "name": "latexmk",
+                        "command": "latexmk",
+                        "args": [
+                            "-shell-escape", // <---- added this line
+                            "-synctex=1",
+                            "-interaction=nonstopmode",
+                            "-file-line-error",
+                            "-pdf",
+                            "-outdir=%OUTDIR%",
+                            "%DOC%"
+                        ],
+                        "env": {}
+                    }
+                ],
+                "latex-workshop.formatting.latexindent.path": "latexindent",
+                "latex-workshop.formatting.latexindent.args": [
                     "-c",
                     "%DIR%/",
                     "%TMPFILE%",


### PR DESCRIPTION
### Description

The dev container now supports D2 diagrams and SVGs in the document

### Type of change

Please select the option that best describes the changes made:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
