### PR TITLE
Fixes erroneous down migration file

### DIFF
--- a/Backend/sql/migrations/00005_history-entries.down.sql
+++ b/Backend/sql/migrations/00005_history-entries.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE click_history IF EXISTS;
+DROP TABLE location_history;


### PR DESCRIPTION
### Description

This PR fixes a down migration that wasn't adjusted after changes had been made to the corresponding up migration. The error wasn't caught because it only triggers when reversing migrations, which wasn't done prior to merging.

### Type of change

Please select the option that best describes the changes made:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Changes

- Replaced table name in down migration