### PR TITLE
Adds hyperref for internal links, removes automatic indent at the start of paragraphs

### DIFF
--- a/Documentation/final-report/structure.tex
+++ b/Documentation/final-report/structure.tex
@@ -48,6 +48,8 @@
 \usepackage{amsmath} % Allows for mathematical symbols
 \usepackage{mdframed} % Allows for framing of text
 
+\usepackage[hidelinks]{hyperref} % Allows for clickable and named references
+
 \definecolor{tudublinblue}{HTML}{004C6C}
 
 %----------------------------------------------------------------------------------------
@@ -69,6 +71,8 @@
 \setlength{\columnsep}{2.5mm} % Column separation width
 
 \setlength{\parskip}{2.5mm} % Increase spacing between paragraphs
+
+\setlength{\parindent}{0pt}
 
 %----------------------------------------------------------------------------------------
 %	FONTS


### PR DESCRIPTION
### Description

Adds the `hyperref` package for internal document links.
Removes the automatic indentation in front of paragraphs.

### Type of change

Please select the option that best describes the changes made:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Changes

- Adds `hyperref`-package
- Removes indentation from paragraphs
